### PR TITLE
Replace `margin-top` with `margin` in shorthand properties example

### DIFF
--- a/shorthand-properties/index.html
+++ b/shorthand-properties/index.html
@@ -24,7 +24,7 @@ margin-left: auto;{% endhighlight %}
 
 <p>превращается в такое:</p>
 
-{% highlight css %}margin-top: 20px auto 35px;{% endhighlight %}
+{% highlight css %}margin: 20px auto 35px;{% endhighlight %}
 
 <p>Получается лаконичная запись, которую удобно и читать, и писать. Однако нужно понимать во что она разворачивается, и что получится, если в ней будут пропущены какие-нибудь свойства.</p>
 


### PR DESCRIPTION
A small typo-fixup for the shorthand properties page. 
It would seem like there should be a `margin` instead of `margin-top` in an example.

P.S. Thanks for the great book! :–)